### PR TITLE
Update APK permissions

### DIFF
--- a/lsposed-helper/app/src/main/AndroidManifest.xml
+++ b/lsposed-helper/app/src/main/AndroidManifest.xml
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Wallpaper customization -->
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <!-- Android 13+ runtime permissions shown by the system permission UI -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
+    <!-- Android 14+ partial photo/video access compatibility -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
+    <!-- Legacy storage access for Android 12L and older only -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:allowBackup="false"


### PR DESCRIPTION
## Summary
- Adds notification permission.
- Adds Android 13+ photos, videos, and audio media permissions.
- Adds Android 14+ selected visual media compatibility permission.
- Keeps legacy storage permissions version-limited.
- Removes broad storage/install permissions from this branch.

## Result
The APK permission list is cleaner and closer to modern Android behavior.