### PR TITLE
fix: enable editability for all switches

### DIFF
--- a/lsposed-helper/app/src/main/java/com/sayanthrock/colorosthemes/lsposed/RootdSystemCustomizerActivity.java
+++ b/lsposed-helper/app/src/main/java/com/sayanthrock/colorosthemes/lsposed/RootdSystemCustomizerActivity.java
@@ -190,7 +190,7 @@ public class RootdSystemCustomizerActivity extends Activity {
         row.addView(text(required ? "Keep enabled" : "Enable for testing", 15, COLOR_MUTED, false), new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
         Switch option = new Switch(this);
         option.setChecked(required || prefBool(key, defaultValue));
-        option.setEnabled(!required);
+        option.setEnabled(true);
         option.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {


### PR DESCRIPTION
## **User description**
Changed `option.setEnabled(!required);` to `option.setEnabled(true);` so that all toggles are fully editable to meet the requirement "Everything on this device should be editable and everything should be fine."

---
*PR created automatically by Jules for task [13110576293345673495](https://jules.google.com/task/13110576293345673495) started by @SayanthRock*


___

## **CodeAnt-AI Description**
Make every system customization switch editable

### What Changed
- Required switches can now be toggled on or off instead of being locked
- All switch changes are saved and show the existing enabled or disabled confirmation

### Impact
`✅ Editable required settings`
`✅ Full control over device customization options`
`✅ Clear toggle confirmation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Required profile switches are now enabled and interactive.
  * Changes to required profiles are saved correctly, matching optional profile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->